### PR TITLE
Fix a few broken documentation links

### DIFF
--- a/docs/machine-learning/classification/k-nearest-neighbors.md
+++ b/docs/machine-learning/classification/k-nearest-neighbors.md
@@ -5,7 +5,7 @@ Classifier implementing the k-nearest neighbors algorithm.
 ## Constructor Parameters
 
 * $k - number of nearest neighbors to scan (default: 3)
-* $distanceMetric - Distance object, default Euclidean (see [distance documentation](math/distance/))
+* $distanceMetric - Distance object, default Euclidean (see [distance documentation](../../math/distance.md))
 
 ```
 $classifier = new KNearestNeighbors($k=4);

--- a/docs/machine-learning/clustering/dbscan.md
+++ b/docs/machine-learning/clustering/dbscan.md
@@ -7,7 +7,7 @@ It is a density-based clustering algorithm: given a set of points in some space,
 
 * $epsilon - epsilon, maximum distance between two samples for them to be considered as in the same neighborhood
 * $minSamples - number of samples in a neighborhood for a point to be considered as a core point (this includes the point itself)
-* $distanceMetric - Distance object, default Euclidean (see [distance documentation](math/distance/))
+* $distanceMetric - Distance object, default Euclidean (see [distance documentation](../../math/distance.md))
 
 ```
 $dbscan = new DBSCAN($epsilon = 2, $minSamples = 3);

--- a/docs/machine-learning/datasets/csv-dataset.md
+++ b/docs/machine-learning/datasets/csv-dataset.md
@@ -12,4 +12,4 @@ Helper class that loads data from CSV file. It extends the `ArrayDataset`.
 $dataset = new CsvDataset('dataset.csv', 2, true);
 ```
 
-See [ArrayDataset](machine-learning/datasets/array-dataset/) for more information.
+See [ArrayDataset](array-dataset.md) for more information.

--- a/docs/machine-learning/datasets/files-dataset.md
+++ b/docs/machine-learning/datasets/files-dataset.md
@@ -12,7 +12,7 @@ use Phpml\Dataset\FilesDataset;
 $dataset = new FilesDataset('path/to/data');
 ```
 
-See [ArrayDataset](machine-learning/datasets/array-dataset/) for more information.
+See [ArrayDataset](array-dataset.md) for more information.
 
 ### Example
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,8 @@ site_name: PHP-ML - Machine Learning library for PHP
 pages:
   - Home: index.md
   - Machine Learning:
+    - Association rule learning:
+      - Apriori: machine-learning/association/apriori.md
     - Classification:
       - SVC: machine-learning/classification/svc.md
       - KNearestNeighbors: machine-learning/classification/k-nearest-neighbors.md
@@ -41,5 +43,6 @@ pages:
   - Math:
     - Distance: math/distance.md
     - Matrix: math/matrix.md
+    - Set: math/set.md
     - Statistic: math/statistic.md
 theme: readthedocs


### PR DESCRIPTION
Hi,

While browsing the documentation I noticed a few broken documentation links (on Github and Read the Docs). I have fixed those broken links and made sure the changes work on both Github and Read the Docs.

Thanks,
Rob