### PR TITLE
Fix division by 0 error during normalization

### DIFF
--- a/src/Phpml/Preprocessing/Normalizer.php
+++ b/src/Phpml/Preprocessing/Normalizer.php
@@ -134,7 +134,12 @@ class Normalizer implements Preprocessor
     private function normalizeSTD(array &$sample)
     {
         foreach ($sample as $i => $val) {
-            $sample[$i] = ($sample[$i] - $this->mean[$i]) / $this->std[$i];
+            if ($this->std[$i] != 0) {
+                $sample[$i] = ($sample[$i] - $this->mean[$i]) / $this->std[$i];
+            } else {
+                // Same value for all samples.
+                $sample[$i] = 0;
+            }
         }
     }
 }

--- a/tests/Phpml/Preprocessing/NormalizerTest.php
+++ b/tests/Phpml/Preprocessing/NormalizerTest.php
@@ -111,6 +111,9 @@ class NormalizerTest extends TestCase
             for ($k=0; $k<3; $k++) {
                 $sample[$k] = rand(1, 100);
             }
+            // Last feature's value shared across samples.
+            $sample[] = 1;
+
             $samples[] = $sample;
         }
 
@@ -126,6 +129,7 @@ class NormalizerTest extends TestCase
                     return $element < -3 || $element > 3;
                 });
             $this->assertCount(0, $errors);
+            $this->assertEquals(0, $sample[3]);
         }
     }
 }


### PR DESCRIPTION
std is 0 when a feature has the same value in samples.