### PR TITLE
Implement PReLU activation function

### DIFF
--- a/src/Phpml/NeuralNetwork/ActivationFunction/PReLU.php
+++ b/src/Phpml/NeuralNetwork/ActivationFunction/PReLU.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpml\NeuralNetwork\ActivationFunction;
+
+use Phpml\NeuralNetwork\ActivationFunction;
+
+class PReLU implements ActivationFunction
+{
+    /**
+     * @var float
+     */
+    private $beta;
+
+    /**
+     * @param float $beta
+     */
+    public function __construct($beta = 0.01)
+    {
+        $this->beta = $beta;
+    }
+
+    /**
+     * @param float|int $value
+     *
+     * @return float
+     */
+    public function compute($value): float
+    {
+        return $value >= 0 ? $value : $this->beta * $value;
+    }
+}


### PR DESCRIPTION
A useful activation function for some networks, you can turn this into a non-leaky ReLU by providing a $beta of 0.0 or a RReLU by providing a random number. Leaky ReLU by default.