### PR TITLE
DBSCAN fix for associative keys and array_merge performance optimization

### DIFF
--- a/src/Phpml/Clustering/DBSCAN.php
+++ b/src/Phpml/Clustering/DBSCAN.php
@@ -94,17 +94,19 @@ class DBSCAN implements Clusterer
     {
         $cluster = [];
 
+        $clusterMerge = [[]];
         foreach ($samples as $index => $sample) {
             if (!isset($visited[$index])) {
                 $visited[$index] = true;
                 $regionSamples = $this->getSamplesInRegion($sample, $samples);
                 if (count($regionSamples) > $this->minSamples) {
-                    $cluster = array_merge($regionSamples, $cluster);
+                    $clusterMerge[] = $regionSamples;
                 }
             }
 
-            $cluster[] = $sample;
+            $cluster[$index] = $sample;
         }
+        $cluster = \array_merge($cluster, ...$clusterMerge);
 
         return $cluster;
     }

--- a/tests/Phpml/Clustering/DBSCANTest.php
+++ b/tests/Phpml/Clustering/DBSCANTest.php
@@ -31,4 +31,17 @@ class DBSCANTest extends TestCase
 
         $this->assertEquals($clustered, $dbscan->cluster($samples));
     }
+
+    public function testDBSCANSamplesClusteringAssociative()
+    {
+        $samples = ['a' => [1, 1], 'b' => [9, 9], 'c' => [1, 2], 'd' => [9, 8], 'e' => [7, 7], 'f' => [8, 7]];
+        $clustered = [
+            ['a' => [1, 1], 'c' => [1, 2]],
+            ['b' => [9, 9], 'd' => [9, 8], 'e' => [7, 7], 'f' => [8, 7]],
+        ];
+
+        $dbscan = new DBSCAN($epsilon = 3, $minSamples = 2);
+
+        $this->assertEquals($clustered, $dbscan->cluster($samples));
+    }
 }


### PR DESCRIPTION
Regarding to https://github.com/php-ai/php-ml/issues/48#issuecomment-337469911