### PR TITLE
Fix backpropagation random error

### DIFF
--- a/tests/Phpml/Classification/MLPClassifierTest.php
+++ b/tests/Phpml/Classification/MLPClassifierTest.php
@@ -112,16 +112,16 @@ class MLPClassifierTest extends TestCase
     public function testBackpropagationLearningMultilayer(): void
     {
         // Multi-layer 2 classes.
-        $network = new MLPClassifier(5, [3, 2], ['a', 'b']);
+        $network = new MLPClassifier(5, [3, 2], ['a', 'b', 'c']);
         $network->train(
             [[1, 0, 0, 0, 0], [0, 1, 1, 0, 0], [1, 1, 1, 1, 1], [0, 0, 0, 0, 0]],
-            ['a', 'b', 'a', 'b']
+            ['a', 'b', 'a', 'c']
         );
 
         $this->assertEquals('a', $network->predict([1, 0, 0, 0, 0]));
         $this->assertEquals('b', $network->predict([0, 1, 1, 0, 0]));
         $this->assertEquals('a', $network->predict([1, 1, 1, 1, 1]));
-        $this->assertEquals('b', $network->predict([0, 0, 0, 0, 0]));
+        $this->assertEquals('c', $network->predict([0, 0, 0, 0, 0]));
     }
 
     public function testBackpropagationLearningMulticlass(): void


### PR DESCRIPTION
Fix for #87. I still need to continue investigating the nn internals and comparing the results using other nn implementations with the same configuration but this should fix the backprop random failures.

I've run **for i in {1..100} ; bin/phpunit --filter=Multilayer** multiple times with 0 failures.