### PR TITLE
Fix string representation of integer labels issue in NaiveBayes

### DIFF
--- a/src/Phpml/Classification/NaiveBayes.php
+++ b/src/Phpml/Classification/NaiveBayes.php
@@ -68,7 +68,7 @@ class NaiveBayes implements Classifier
 
         $labelCounts = array_count_values($this->targets);
         $this->labels = array_keys($labelCounts);
-        $this->labels = array_map('strval', $this->labels);
+        $this->labels = array_unique(array_map('strval', $this->labels));
         foreach ($this->labels as $label) {
             $samples = $this->getSamplesByLabel($label);
             $this->p[$label] = count($samples) / $this->sampleCount;

--- a/src/Phpml/Classification/NaiveBayes.php
+++ b/src/Phpml/Classification/NaiveBayes.php
@@ -69,7 +69,6 @@ class NaiveBayes implements Classifier
         $labelCounts = array_count_values($this->targets);
         $this->labels = array_keys($labelCounts);
         $this->labels = array_map('strval', $this->labels);
-            
         foreach ($this->labels as $label) {
             $samples = $this->getSamplesByLabel($label);
             $this->p[$label] = count($samples) / $this->sampleCount;

--- a/src/Phpml/Classification/NaiveBayes.php
+++ b/src/Phpml/Classification/NaiveBayes.php
@@ -66,8 +66,7 @@ class NaiveBayes implements Classifier
         $this->sampleCount = count($this->samples);
         $this->featureCount = count($this->samples[0]);
 
-        $labels = array_flip(array_flip($this->targets));
-        $this->labels = array_map('strval', $labels);
+        $this->labels = array_map('strval', array_flip(array_flip($this->targets)));
         foreach ($this->labels as $label) {
             $samples = $this->getSamplesByLabel($label);
             $this->p[$label] = count($samples) / $this->sampleCount;

--- a/src/Phpml/Classification/NaiveBayes.php
+++ b/src/Phpml/Classification/NaiveBayes.php
@@ -66,9 +66,8 @@ class NaiveBayes implements Classifier
         $this->sampleCount = count($this->samples);
         $this->featureCount = count($this->samples[0]);
 
-        $labelCounts = array_count_values($this->targets);
-        $this->labels = array_keys($labelCounts);
-        $this->labels = array_unique(array_map('strval', $this->labels));
+        $labels = array_flip(array_flip($this->targets));
+        $this->labels = array_map('strval', $labels);
         foreach ($this->labels as $label) {
             $samples = $this->getSamplesByLabel($label);
             $this->p[$label] = count($samples) / $this->sampleCount;

--- a/tests/Phpml/Classification/NaiveBayesTest.php
+++ b/tests/Phpml/Classification/NaiveBayesTest.php
@@ -59,7 +59,66 @@ class NaiveBayesTest extends TestCase
         $classifier->train($trainSamples, $trainLabels);
         $predicted = $classifier->predict($testSamples);
 
-        $filename = 'naive-bayes-test-'.random_int(100, 999).'-'.uniqid();
+        $filename = 'naive-bayes-test-' . random_int(100, 999) . '-' . uniqid();
+        $filepath = tempnam(sys_get_temp_dir(), $filename);
+        $modelManager = new ModelManager();
+        $modelManager->saveToFile($classifier, $filepath);
+
+        $restoredClassifier = $modelManager->restoreFromFile($filepath);
+        $this->assertEquals($classifier, $restoredClassifier);
+        $this->assertEquals($predicted, $restoredClassifier->predict($testSamples));
+    }
+
+    public function testPredictSimpleNumericLabels(): void
+    {
+        $samples = [[5, 1, 1], [1, 5, 1], [1, 1, 5]];
+        $labels = ['1996', '1997', '1998'];
+
+        $classifier = new NaiveBayes();
+        $classifier->train($samples, $labels);
+
+        $this->assertEquals('1996', $classifier->predict([3, 1, 1]));
+        $this->assertEquals('1997', $classifier->predict([1, 4, 1]));
+        $this->assertEquals('1998', $classifier->predict([1, 1, 6]));
+    }
+
+    public function testPredictArrayOfSamplesNumericalLabels(): void
+    {
+        $trainSamples = [[5, 1, 1], [1, 5, 1], [1, 1, 5]];
+        $trainLabels = ['1996', '1997', '1998'];
+
+        $testSamples = [[3, 1, 1], [5, 1, 1], [4, 3, 8], [1, 1, 2], [2, 3, 2], [1, 2, 1], [9, 5, 1], [3, 1, 2]];
+        $testLabels = ['1996', '1996', '1998', '1998', '1997', '1997', '1996', '1996'];
+
+        $classifier = new NaiveBayes();
+        $classifier->train($trainSamples, $trainLabels);
+        $predicted = $classifier->predict($testSamples);
+
+        $this->assertEquals($testLabels, $predicted);
+
+        // Feed an extra set of training data.
+        $samples = [[1, 1, 6]];
+        $labels = ['1999'];
+        $classifier->train($samples, $labels);
+
+        $testSamples = [[1, 1, 6], [5, 1, 1]];
+        $testLabels = ['1999', '1996'];
+        $this->assertEquals($testLabels, $classifier->predict($testSamples));
+    }
+
+    public function testSaveAndRestoreNumericLabels(): void
+    {
+        $trainSamples = [[5, 1, 1], [1, 5, 1], [1, 1, 5]];
+        $trainLabels = ['1996', '1997', '1998'];
+
+        $testSamples = [[3, 1, 1], [5, 1, 1], [4, 3, 8]];
+        $testLabels = ['1996', '1996', '1998'];
+
+        $classifier = new NaiveBayes();
+        $classifier->train($trainSamples, $trainLabels);
+        $predicted = $classifier->predict($testSamples);
+
+        $filename = 'naive-bayes-test-' . random_int(100, 999) . '-' . uniqid();
         $filepath = tempnam(sys_get_temp_dir(), $filename);
         $modelManager = new ModelManager();
         $modelManager->saveToFile($classifier, $filepath);

--- a/tests/Phpml/Classification/NaiveBayesTest.php
+++ b/tests/Phpml/Classification/NaiveBayesTest.php
@@ -59,7 +59,7 @@ class NaiveBayesTest extends TestCase
         $classifier->train($trainSamples, $trainLabels);
         $predicted = $classifier->predict($testSamples);
 
-        $filename = 'naive-bayes-test-' . random_int(100, 999) . '-' . uniqid();
+        $filename = 'naive-bayes-test-'.random_int(100, 999).'-'.uniqid();
         $filepath = tempnam(sys_get_temp_dir(), $filename);
         $modelManager = new ModelManager();
         $modelManager->saveToFile($classifier, $filepath);
@@ -118,7 +118,7 @@ class NaiveBayesTest extends TestCase
         $classifier->train($trainSamples, $trainLabels);
         $predicted = $classifier->predict($testSamples);
 
-        $filename = 'naive-bayes-test-' . random_int(100, 999) . '-' . uniqid();
+        $filename = 'naive-bayes-test-'.random_int(100, 999).'-'.uniqid();
         $filepath = tempnam(sys_get_temp_dir(), $filename);
         $modelManager = new ModelManager();
         $modelManager->saveToFile($classifier, $filepath);


### PR DESCRIPTION
In the classification module NaiveBayes, there is a bug that affects use of data with targets that are strings representations of integers.

The offending lines are 67-70 in the NaiveBayes class:

```php
$labelCounts = array_count_values($this->targets);
$this->labels = array_keys($labelCounts);
...
$samples = $this->getSamplesByLabel($label);
```

The combination internally casts any integer-like strings into integers. This then breaks `getSamplesByLabel` since it requires a string input.

This PR fixes the issue by ensuring the labels are always strings.

E.g. Using years as labels before this change causes the following error:

```php
$samples = [[1, 0, 1], [0, 0, 0]];
$targets = ['1997', '1998'];
(new NaiveBayes)->train($samples, $targets);
```

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Phpml\Classification\NaiveBayes::getSamplesByLabel() must be of the type string, integer given, called in /Users/jon/Code/ml/vendor/php-ai/php-ml/src/Phpml/Classification/NaiveBayes.php on line 70 and defined in /Users/jon/Code/ml/vendor/php-ai/php-ml/src/Phpml/Classification/NaiveBayes.php:140
Stack trace:
#0 /Users/jon/Code/ml/vendor/php-ai/php-ml/src/Phpml/Classification/NaiveBayes.php(70): Phpml\Classification\NaiveBayes->getSamplesByLabel(1998)
#1 /Users/jon/Code/ml/mlp.php(51): Phpml\Classification\NaiveBayes->train(Array, Array)
#2 {main}
  thrown in /Users/jon/Code/ml/vendor/php-ai/php-ml/src/Phpml/Classification/NaiveBayes.php on line 140

Fatal error: Uncaught TypeError: Argument 1 passed to Phpml\Classification\NaiveBayes::getSamplesByLabel() must be of the type string, integer given, called in /Users/jon/Code/ml/vendor/php-ai/php-ml/src/Phpml/Classification/NaiveBayes.php on line 70 and defined in /Users/jon/Code/ml/vendor/php-ai/php-ml/src/Phpml/Classification/NaiveBayes.php:140
Stack trace:
#0 /Users/jon/Code/ml/vendor/php-ai/php-ml/src/Phpml/Classification/NaiveBayes.php(70): Phpml\Classification\NaiveBayes->getSamplesByLabel(1998)
#1 /Users/jon/Code/ml/mlp.php(51): Phpml\Classification\NaiveBayes->train(Array, Array)
#2 {main}
  thrown in /Users/jon/Code/ml/vendor/php-ai/php-ml/src/Phpml/Classification/NaiveBayes.php on line 140```