### PR TITLE
Configure an Activation Function per hidden layer

### DIFF
--- a/docs/machine-learning/neural-network/multilayer-perceptron-classifier.md
+++ b/docs/machine-learning/neural-network/multilayer-perceptron-classifier.md
@@ -19,6 +19,24 @@ $mlp = new MLPClassifier(4, [2], ['a', 'b', 'c']);
 
 ```
 
+An Activation Function may also be passed in with each individual hidden layer. Example:
+
+```
+use Phpml\NeuralNetwork\ActivationFunction\PReLU;
+use Phpml\NeuralNetwork\ActivationFunction\Sigmoid;
+$mlp = new MLPClassifier(4, [[2, new PReLU], [2, new Sigmoid]], ['a', 'b', 'c']);
+```
+
+Instead of configuring each hidden layer as an array, they may also be configured with Layer objects. Example:
+
+```
+use Phpml\NeuralNetwork\Layer;
+use Phpml\NeuralNetwork\Node\Neuron;
+$layer1 = new Layer(2, Neuron::class, new PReLU);
+$layer2 = new Layer(2, Neuron::class, new Sigmoid);
+$mlp = new MLPClassifier(4, [$layer1, $layer2], ['a', 'b', 'c']);
+```
+
 ## Train
 
 To train a MLP simply provide train samples and labels (as array). Example:

--- a/src/Phpml/NeuralNetwork/Network/MultilayerPerceptron.php
+++ b/src/Phpml/NeuralNetwork/Network/MultilayerPerceptron.php
@@ -142,10 +142,14 @@ abstract class MultilayerPerceptron extends LayeredNetwork implements Estimator,
         $this->addLayer(new Layer($nodes, Input::class));
     }
 
-    private function addNeuronLayers(array $layers, ?ActivationFunction $activationFunction = null): void
+    private function addNeuronLayers(array $layers, ?ActivationFunction $defaultActivationFunction = null): void
     {
-        foreach ($layers as $neurons) {
-            $this->addLayer(new Layer($neurons, Neuron::class, $activationFunction));
+        foreach ($layers as $layer) {
+            if (is_array($layer) && end($layer) instanceof ActivationFunction) {
+                $this->addLayer(new Layer($layer[0], Neuron::class,  $layer[1]));
+            } else {
+                $this->addLayer(new Layer($layer, Neuron::class,  $defaultActivationFunction));
+            }
         }
     }
 

--- a/src/Phpml/NeuralNetwork/Network/MultilayerPerceptron.php
+++ b/src/Phpml/NeuralNetwork/Network/MultilayerPerceptron.php
@@ -146,9 +146,9 @@ abstract class MultilayerPerceptron extends LayeredNetwork implements Estimator,
     {
         foreach ($layers as $layer) {
             if (is_array($layer) && end($layer) instanceof ActivationFunction) {
-                $this->addLayer(new Layer($layer[0], Neuron::class,  $layer[1]));
+                $this->addLayer(new Layer($layer[0], Neuron::class, $layer[1]));
             } else {
-                $this->addLayer(new Layer($layer, Neuron::class,  $defaultActivationFunction));
+                $this->addLayer(new Layer($layer, Neuron::class, $defaultActivationFunction));
             }
         }
     }

--- a/src/Phpml/NeuralNetwork/Network/MultilayerPerceptron.php
+++ b/src/Phpml/NeuralNetwork/Network/MultilayerPerceptron.php
@@ -145,8 +145,11 @@ abstract class MultilayerPerceptron extends LayeredNetwork implements Estimator,
     private function addNeuronLayers(array $layers, ?ActivationFunction $defaultActivationFunction = null): void
     {
         foreach ($layers as $layer) {
-            if (is_array($layer) && end($layer) instanceof ActivationFunction) {
-                $this->addLayer(new Layer($layer[0], Neuron::class, $layer[1]));
+            if (is_array($layer)) {
+                $function = $layer[1] instanceof ActivationFunction ? $layer[1] : $defaultActivationFunction;
+                $this->addLayer(new Layer($layer[0], Neuron::class, $function));
+            } elseif ($layer instanceof Layer) {
+                $this->addLayer($layer);
             } else {
                 $this->addLayer(new Layer($layer, Neuron::class, $defaultActivationFunction));
             }

--- a/tests/Phpml/NeuralNetwork/Network/LayeredNetworkTest.php
+++ b/tests/Phpml/NeuralNetwork/Network/LayeredNetworkTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Phpml\Tests\NeuralNetwork\Network;
 
+use Phpml\NeuralNetwork\ActivationFunction;
 use Phpml\NeuralNetwork\Layer;
 use Phpml\NeuralNetwork\Network\LayeredNetwork;
 use Phpml\NeuralNetwork\Node\Input;
@@ -45,11 +46,28 @@ class LayeredNetworkTest extends TestCase
         $this->assertEquals([0.5], $network->getOutput());
     }
 
+    public function testSetInputAndGetOutputWithCustomActivationFunctions(): void
+    {
+        $network = $this->getLayeredNetworkMock();
+        $network->addLayer(new Layer(2, Input::class, $this->getActivationFunctionMock()));
+
+        $network->setInput($input = [34, 43]);
+        $this->assertEquals($input, $network->getOutput());
+    }
+
     /**
      * @return LayeredNetwork|PHPUnit_Framework_MockObject_MockObject
      */
     private function getLayeredNetworkMock()
     {
         return $this->getMockForAbstractClass(LayeredNetwork::class);
+    }
+
+    /**
+     * @return ActivationFunction|PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getActivationFunctionMock()
+    {
+        return $this->getMockForAbstractClass(ActivationFunction::class);
     }
 }

--- a/tests/Phpml/NeuralNetwork/Network/MultilayerPerceptronTest.php
+++ b/tests/Phpml/NeuralNetwork/Network/MultilayerPerceptronTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Phpml\Tests\NeuralNetwork\Network;
 
+use Phpml\NeuralNetwork\ActivationFunction;
 use Phpml\NeuralNetwork\Network\MultilayerPerceptron;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
 
 class MultilayerPerceptronTest extends TestCase
 {
@@ -25,5 +27,33 @@ class MultilayerPerceptronTest extends TestCase
         $this->assertEquals(0.24, $this->readAttribute($mlp, 'learningRate'));
         $backprop = $this->readAttribute($mlp, 'backpropagation');
         $this->assertEquals(0.24, $this->readAttribute($backprop, 'learningRate'));
+    }
+
+    public function testLearningRateSetterWithCustomActivationFunctions(): void
+    {
+        $activation_function = $this->getActivationFunctionMock();
+
+        /** @var MultilayerPerceptron $mlp */
+        $mlp = $this->getMockForAbstractClass(
+            MultilayerPerceptron::class,
+            [5, [[3, $activation_function], [5, $activation_function]], [0, 1], 1000, null, 0.42]
+        );
+
+        $this->assertEquals(0.42, $this->readAttribute($mlp, 'learningRate'));
+        $backprop = $this->readAttribute($mlp, 'backpropagation');
+        $this->assertEquals(0.42, $this->readAttribute($backprop, 'learningRate'));
+
+        $mlp->setLearningRate(0.24);
+        $this->assertEquals(0.24, $this->readAttribute($mlp, 'learningRate'));
+        $backprop = $this->readAttribute($mlp, 'backpropagation');
+        $this->assertEquals(0.24, $this->readAttribute($backprop, 'learningRate'));
+    }
+
+    /**
+     * @return ActivationFunction|PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getActivationFunctionMock()
+    {
+        return $this->getMockForAbstractClass(ActivationFunction::class);
     }
 }

--- a/tests/Phpml/NeuralNetwork/Network/MultilayerPerceptronTest.php
+++ b/tests/Phpml/NeuralNetwork/Network/MultilayerPerceptronTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Phpml\Tests\NeuralNetwork\Network;
 
 use Phpml\NeuralNetwork\ActivationFunction;
+use Phpml\NeuralNetwork\Layer;
 use Phpml\NeuralNetwork\Network\MultilayerPerceptron;
+use Phpml\NeuralNetwork\Node\Neuron;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 
@@ -37,6 +39,26 @@ class MultilayerPerceptronTest extends TestCase
         $mlp = $this->getMockForAbstractClass(
             MultilayerPerceptron::class,
             [5, [[3, $activation_function], [5, $activation_function]], [0, 1], 1000, null, 0.42]
+        );
+
+        $this->assertEquals(0.42, $this->readAttribute($mlp, 'learningRate'));
+        $backprop = $this->readAttribute($mlp, 'backpropagation');
+        $this->assertEquals(0.42, $this->readAttribute($backprop, 'learningRate'));
+
+        $mlp->setLearningRate(0.24);
+        $this->assertEquals(0.24, $this->readAttribute($mlp, 'learningRate'));
+        $backprop = $this->readAttribute($mlp, 'backpropagation');
+        $this->assertEquals(0.24, $this->readAttribute($backprop, 'learningRate'));
+    }
+
+    public function testLearningRateSetterWithLayerObject(): void
+    {
+        $activation_function = $this->getActivationFunctionMock();
+
+        /** @var MultilayerPerceptron $mlp */
+        $mlp = $this->getMockForAbstractClass(
+            MultilayerPerceptron::class,
+            [5, [new Layer(3, Neuron::class, $activation_function), new Layer(5, Neuron::class, $activation_function)], [0, 1], 1000, null, 0.42]
         );
 
         $this->assertEquals(0.42, $this->readAttribute($mlp, 'learningRate'));


### PR DESCRIPTION
To address proposal of issue #207.

Grants ability in Layered Networks to specify a custom Activation Function per hidden layer, instead of one Activation Function for every layer like before. This is a common functionality in other ML libraries.

E.g.

```php
$mlp = new MLPClassifier($input, [[2, new PReLU], [2, new Sigmoid]], ['a', 'b', 'c']);
```