### PR TITLE
Enhancement: Cache dependencies installed with composer on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ matrix:
         - _OSX=10.11
         - _PHP: php71
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_install:
   - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then /usr/bin/env bash bin/prepare_osx_env.sh ; fi
   - if [[ $DISABLE_XDEBUG == "true" ]]; then phpenv config-rm xdebug.ini; fi

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "symplify/easy-coding-standard": "^3.1"
     },
     "config": {
+        "preferred-install": "dist",
         "sort-packages": true
     },
     "autoload": {


### PR DESCRIPTION
This PR

* [x] caches dependencies installed with `composer` on Travis

💁‍♂️ For reference, see https://docs.travis-ci.com/user/caching/#Arbitrary-directories.