### PR TITLE
Fix Optimizer initial theta randomization

### DIFF
--- a/src/Helper/Optimizer/Optimizer.php
+++ b/src/Helper/Optimizer/Optimizer.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Phpml\Helper\Optimizer;
 
 use Closure;
-use Exception;
+use Phpml\Exception\InvalidArgumentException;
 
 abstract class Optimizer
 {
+    public $initialTheta;
+
     /**
      * Unknown variables to be found
      *
@@ -33,21 +35,16 @@ abstract class Optimizer
         // Inits the weights randomly
         $this->theta = [];
         for ($i = 0; $i < $this->dimensions; ++$i) {
-            $this->theta[] = random_int(0, getrandmax()) / (float) getrandmax();
+            $this->theta[] = (random_int(0, PHP_INT_MAX) / PHP_INT_MAX) + 0.1;
         }
+
+        $this->initialTheta = $this->theta;
     }
 
-    /**
-     * Sets the weights manually
-     *
-     * @return $this
-     *
-     * @throws \Exception
-     */
     public function setInitialTheta(array $theta)
     {
         if (count($theta) != $this->dimensions) {
-            throw new Exception("Number of values in the weights array should be ${this}->dimensions");
+            throw new InvalidArgumentException(sprintf('Number of values in the weights array should be %s', $this->dimensions));
         }
 
         $this->theta = $theta;

--- a/src/Helper/Optimizer/StochasticGD.php
+++ b/src/Helper/Optimizer/StochasticGD.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phpml\Helper\Optimizer;
 
 use Closure;
+use Phpml\Exception\InvalidArgumentException;
 
 /**
  * Stochastic Gradient Descent optimization method
@@ -86,6 +87,17 @@ class StochasticGD extends Optimizer
         parent::__construct($dimensions + 1);
 
         $this->dimensions = $dimensions;
+    }
+
+    public function setInitialTheta(array $theta)
+    {
+        if (count($theta) != $this->dimensions + 1) {
+            throw new InvalidArgumentException(sprintf('Number of values in the weights array should be %s', $this->dimensions + 1));
+        }
+
+        $this->theta = $theta;
+
+        return $this;
     }
 
     /**

--- a/src/Math/LinearAlgebra/LUDecomposition.php
+++ b/src/Math/LinearAlgebra/LUDecomposition.php
@@ -225,25 +225,14 @@ class LUDecomposition
         return true;
     }
 
-    /**
-     * Count determinants
-     *
-     * @return float|int d matrix determinant
-     *
-     * @throws MatrixException
-     */
-    public function det()
+    public function det(): float
     {
-        if ($this->m !== $this->n) {
-            throw MatrixException::notSquareMatrix();
-        }
-
         $d = $this->pivsign;
         for ($j = 0; $j < $this->n; ++$j) {
             $d *= $this->LU[$j][$j];
         }
 
-        return $d;
+        return (float) $d;
     }
 
     /**

--- a/tests/Clustering/FuzzyCMeansTest.php
+++ b/tests/Clustering/FuzzyCMeansTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phpml\Tests\Clustering;
 
 use Phpml\Clustering\FuzzyCMeans;
+use Phpml\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class FuzzyCMeansTest extends TestCase
@@ -44,5 +45,20 @@ class FuzzyCMeansTest extends TestCase
         foreach ($matrix as $col) {
             $this->assertEquals(1, array_sum($col));
         }
+    }
+
+    /**
+     * @dataProvider invalidClusterNumberProvider
+     */
+    public function testInvalidClusterNumber(int $clusters): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new FuzzyCMeans($clusters);
+    }
+
+    public function invalidClusterNumberProvider(): array
+    {
+        return [[0], [-1]];
     }
 }

--- a/tests/Math/LinearAlgebra/LUDecompositionTest.php
+++ b/tests/Math/LinearAlgebra/LUDecompositionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpml\Tests\Math\LinearAlgebra;
+
+use Phpml\Exception\MatrixException;
+use Phpml\Math\LinearAlgebra\LUDecomposition;
+use Phpml\Math\Matrix;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * LUDecomposition is used and tested in Matrix::inverse method so not all tests are required
+ */
+final class LUDecompositionTest extends TestCase
+{
+    public function testNotSquareMatrix(): void
+    {
+        $this->expectException(MatrixException::class);
+
+        new LUDecomposition(new Matrix([1, 2, 3, 4, 5]));
+    }
+
+    public function testSolveWithInvalidMatrix(): void
+    {
+        $this->expectException(MatrixException::class);
+
+        $lu = new LUDecomposition(new Matrix([[1, 2], [3, 4]]));
+        $lu->solve(new Matrix([1, 2, 3]));
+    }
+}


### PR DESCRIPTION
In this PR:
- [x] Fix `Optimizer` initial theta randomization - this cause random error in tests (when very low theta was generated - see test `ConjugateGradientTest::testRunOptimizationWithCustomInitialTheta`
- [x] Add tests for `LUDecomposition` and `FuzzyCMeans`