### PR TITLE
Micro optimization for matrix multiplication

### DIFF
--- a/src/Math/Matrix.php
+++ b/src/Math/Matrix.php
@@ -142,19 +142,23 @@ class Matrix
             throw new InvalidArgumentException('Inconsistent matrix supplied');
         }
 
-        $product = [];
-        $multiplier = $matrix->toArray();
-        for ($i = 0; $i < $this->rows; ++$i) {
-            $columns = $matrix->getColumns();
-            for ($j = 0; $j < $columns; ++$j) {
-                $product[$i][$j] = 0;
-                for ($k = 0; $k < $this->columns; ++$k) {
-                    $product[$i][$j] += $this->matrix[$i][$k] * $multiplier[$k][$j];
-                }
-            }
-        }
+		$array1 = $this->toArray();
+		$array2 = $matrix->toArray();
+		$colCount = $matrix->columns;
 
-        return new self($product, false);
+		$product = [];
+		foreach($array1 as $row => $rowData){
+			for($col = 0; $col < $colCount; ++$col) {
+				$columnData = array_column($array2, $col);
+				$sum = 0;
+				foreach($rowData as $key => $valueData) {
+					$sum += $valueData * $columnData[$key];
+				}
+				$product[$row][$col] = $sum;
+			}
+		}
+
+		return new self($product, false);
     }
 
     public function divideByScalar($value): self

--- a/src/Math/Matrix.php
+++ b/src/Math/Matrix.php
@@ -142,23 +142,24 @@ class Matrix
             throw new InvalidArgumentException('Inconsistent matrix supplied');
         }
 
-		$array1 = $this->toArray();
-		$array2 = $matrix->toArray();
-		$colCount = $matrix->columns;
+        $array1 = $this->toArray();
+        $array2 = $matrix->toArray();
+        $colCount = $matrix->columns;
 
-		$product = [];
-		foreach($array1 as $row => $rowData){
-			for($col = 0; $col < $colCount; ++$col) {
-				$columnData = array_column($array2, $col);
-				$sum = 0;
-				foreach($rowData as $key => $valueData) {
-					$sum += $valueData * $columnData[$key];
-				}
-				$product[$row][$col] = $sum;
-			}
-		}
+        $product = [];
+        foreach ($array1 as $row => $rowData) {
+            for ($col = 0; $col < $colCount; ++$col) {
+                $columnData = array_column($array2, $col);
+                $sum = 0;
+                foreach ($rowData as $key => $valueData) {
+                    $sum += $valueData * $columnData[$key];
+                }
 
-		return new self($product, false);
+                $product[$row][$col] = $sum;
+            }
+        }
+
+        return new self($product, false);
     }
 
     public function divideByScalar($value): self

--- a/src/Math/Matrix.php
+++ b/src/Math/Matrix.php
@@ -146,6 +146,10 @@ class Matrix
         $array2 = $matrix->toArray();
         $colCount = $matrix->columns;
 
+        /*
+         - To speed-up multiplication, we need to avoid use of array index operator [ ] as much as possible( See #255 for details)
+         - A combination of "foreach" and "array_column" works much faster then accessing the array via index operator
+        */
         $product = [];
         foreach ($array1 as $row => $rowData) {
             for ($col = 0; $col < $colCount; ++$col) {


### PR DESCRIPTION
Hi,

The change proposed in this PR boosts the performance of Matrix::multiply().

Here is how:

- arrays in PHP are actually HashTable implementations. Therefore, each access to an array element via index operator `[ ]` requires a hash calculation and thus slow.
- whereas, accessing the array via `foreach` is faster because it does not require the hash calculation
- A combination of `foreach` and `array_column` is faster than using indexes.

Comparison of current Matrix::multiply() performance with the proposed one in this PR:

``` 
Current matrix multiplication implementation:
100 x 100 matrix: 0,11128902435303 sec 
200 x 200 matrix: 0,85332202911377 sec 
300 x 300 matrix: 2,9366030693054 sec 
400 x 400 matrix: 7,8980741500854 sec 
500 x 500 matrix: 14,669856071472 sec 
600 x 600 matrix: 25,229273796082 sec 
700 x 700 matrix: 40,773044109344 sec 
800 x 800 matrix: 61,298209905624 sec 
900 x 900 matrix: 91,823884010315 sec 
1000 x 1000 matrix: 140,66364216805 sec 
```
``` 
Proposed implementation:
100 x 100 matrix: 0,052306890487671 sec 
200 x 200 matrix: 0,40823483467102 sec 
300 x 300 matrix: 1,3276610374451 sec 
400 x 400 matrix: 3,2287139892578 sec 
500 x 500 matrix: 6,3201858997345 sec 
600 x 600 matrix: 11,429125070572 sec 
700 x 700 matrix: 17,821397066116 sec 
800 x 800 matrix: 28,033140897751 sec 
900 x 900 matrix: 40,414824008942 sec 
1000 x 1000 matrix: 60,000021934509 sec  
```
P.S: I am no expert on PHP internals, these information are something I've collected online and what I've understood from people who knows it better. You can find some stackoverflow posts and web pages about similar discussion. I've used these web pages but I cannot provide them at the moment because it has been a while since I last checked them.