### PR TITLE
Added isset to sample feature array. Problem: while using ModelManger…

### DIFF
--- a/src/Classification/NaiveBayes.php
+++ b/src/Classification/NaiveBayes.php
@@ -136,7 +136,7 @@ class NaiveBayes implements Classifier
      */
     private function sampleProbability(array $sample, int $feature, string $label): float
     {
-        $value = $sample[$feature];
+        $value = (isset($sample[$feature]))? $sample[$feature] : null;
         if ($this->dataType[$label][$feature] == self::NOMINAL) {
             if (!isset($this->discreteProb[$label][$feature][$value]) ||
                 $this->discreteProb[$label][$feature][$value] == 0) {


### PR DESCRIPTION
When using ModelManager, NaiveBayes fails on restoration and use of the classifier. One of the issues I spotted was on line 139, the $sample[$feature] did not contain an isset() check. So I added one. This helped in debugging the next step. I recommend we keep it. 