### PR TITLE
Tweaks to the TF-LDF transformer

### DIFF
--- a/tests/FeatureExtraction/TfIdfTransformerTest.php
+++ b/tests/FeatureExtraction/TfIdfTransformerTest.php
@@ -7,12 +7,17 @@ namespace Phpml\Tests\FeatureExtraction;
 use Phpml\FeatureExtraction\TfIdfTransformer;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Class TfIdfTransformerTest
+ *
+ * @see https://en.wikipedia.org/wiki/Tf-idf
+ *
+ * @package Phpml\Tests\FeatureExtraction
+ */
 class TfIdfTransformerTest extends TestCase
 {
-    public function testTfIdfTransformation(): void
+    public function testSimpleTransformation(): void
     {
-        // https://en.wikipedia.org/wiki/Tf-idf
-
         $samples = [
             [
                 0 => 1,
@@ -55,5 +60,45 @@ class TfIdfTransformerTest extends TestCase
         $transformer->transform($samples);
 
         self::assertEqualsWithDelta($tfIdfSamples, $samples, 0.001);
+    }
+
+    public function testTransformationWithMinIdf(): void
+    {
+        $samples = [
+            [1, 1, 2, 1, 0, 0],
+            [1, 1, 0, 0, 2, 3],
+        ];
+
+        (new TfIdfTransformer($samples, 1, 0.3))->transform($samples);
+
+        self::assertEqualsWithDelta(
+            [
+                [0.602, 0.301, 0, 0],
+                [0, 0, 0.602, 0.903],
+            ],
+            $samples,
+            0.001
+        );
+    }
+
+    public function testTransformationWithMinTf(): void
+    {
+        $samples = [
+            [0, 0, 0],
+            [1, 1, 0],
+            [1, 1, 1],
+        ];
+
+        (new TfIdfTransformer($samples, 2))->transform($samples);
+
+        self::assertEqualsWithDelta(
+            [
+                [0.0, 0.0],
+                [0.17609125905568124, 0.17609125905568124],
+                [0.17609125905568124, 0.17609125905568124],
+            ],
+            $samples,
+            0.001
+        );
     }
 }


### PR DESCRIPTION
This addresses #162, at least partially, by doing a few things:
 * Allowing for matrices with a zero word count (fixes divide by zero error)
 * Adding the functionality to filter sparse matrices given a minimum TF and IDF value.

The first item is just a bug fix. The second helps with memory consumption by helping filter out irrelevant data from matrices given the proper parameters. Existing tests pass and the default values given should ensure backwards compatibility. 

My apologies if I have made any mistakes or am misunderstanding a concept. I am learning as I go and attempting to solve problems as I reach them. If criticism is warranted, definitely share it!