### PR TITLE
Update clustering to allow access point data

### DIFF
--- a/src/Clustering/FuzzyCMeans.php
+++ b/src/Clustering/FuzzyCMeans.php
@@ -112,7 +112,7 @@ class FuzzyCMeans implements Clusterer
         // Return grouped samples
         $grouped = [];
         foreach ($this->clusters as $cluster) {
-            $grouped[] = $cluster->getPoints();
+            $grouped[] = $cluster->toArray()['points'];
         }
 
         return $grouped;

--- a/src/Clustering/KMeans.php
+++ b/src/Clustering/KMeans.php
@@ -42,7 +42,7 @@ class KMeans implements Clusterer
 
         $clusters = [];
         foreach ($space->cluster($this->clustersNumber, $this->initialization) as $cluster) {
-            $clusters[] = $cluster->getPoints();
+            $clusters[] = $cluster->toArray()['points'];
         }
 
         return $clusters;

--- a/src/Clustering/KMeans/Cluster.php
+++ b/src/Clustering/KMeans/Cluster.php
@@ -41,6 +41,11 @@ class Cluster extends Point implements IteratorAggregate
         return $points;
     }
 
+    public function getSpace(): Space
+    {
+        return $this->space;
+    }
+
     public function toArray(): array
     {
         return [

--- a/src/Clustering/KMeans/Cluster.php
+++ b/src/Clustering/KMeans/Cluster.php
@@ -32,9 +32,9 @@ class Cluster extends Point implements IteratorAggregate
         $points = [];
         foreach ($this->points as $point) {
             if ($point->label === null) {
-                $points[] = $point->toArray();
+                $points[] = $point;
             } else {
-                $points[$point->label] = $point->toArray();
+                $points[$point->label] = $point;
             }
         }
 
@@ -45,7 +45,9 @@ class Cluster extends Point implements IteratorAggregate
     {
         return [
             'centroid' => parent::toArray(),
-            'points' => $this->getPoints(),
+            'points' => array_map(function ($point) {
+                return $point->toArray();
+            }, $this->getPoints()),
         ];
     }
 

--- a/tests/Clustering/KMeans/ClusterTest.php
+++ b/tests/Clustering/KMeans/ClusterTest.php
@@ -43,6 +43,14 @@ class ClusterTest extends TestCase
         self::assertSame([$point], $cluster->getPoints());
     }
 
+    public function testGetSpace(): void
+    {
+        $space = new Space(2);
+        $cluster = new Cluster($space, [1, 2]);
+
+        self::assertSame($space, $cluster->getSpace());
+    }
+
     public function testDetach(): void
     {
         $cluster = new Cluster(new Space(2), []);

--- a/tests/Clustering/KMeans/ClusterTest.php
+++ b/tests/Clustering/KMeans/ClusterTest.php
@@ -34,6 +34,15 @@ class ClusterTest extends TestCase
         ], $cluster->toArray());
     }
 
+    public function testGetPoints(): void
+    {
+        $cluster = new Cluster(new Space(2), [1, 2]);
+        $point = new Point([1, 1]);
+        $cluster->attach($point);
+
+        self::assertSame([$point], $cluster->getPoints());
+    }
+
     public function testDetach(): void
     {
         $cluster = new Cluster(new Space(2), []);


### PR DESCRIPTION
This PR makes 2 changes:
 - getPoints returns `Point[]`, instead of the coordinates.
 - Make the cluster's space accessible.

The aim of those modifications is to access the data associated to a Point.

```php
$space = new Space(3);

foreach ($list as $item) {
  $space->addPoint($item['coordinates'], $item['label'], $item['data']);
}

$clusters = $space->cluster(8, KMeans::INIT_KMEANS_PLUS_PLUS);
```

[...]

```php
foreach ($clusters as $cluster) {
  $clusterPoints = $cluster->getPoints();
  $point = $cluster->getClosest($clusterPoints); // Closetst point from the cluster's centroid

  $space = $cluster->getSpace();
  $data = $space[$point]; // $item['data']
}
```